### PR TITLE
fix: Fix issue 83 in python-lotion

### DIFF
--- a/src/lotion/block/rich_text/rich_text_element.py
+++ b/src/lotion/block/rich_text/rich_text_element.py
@@ -42,9 +42,16 @@ class RichTextElement(metaclass=ABCMeta):
         type = rich_text_element["type"]
         if type == "text":
             text = rich_text_element["text"]
+            link = text.get("link")
+            link_url = None
+            link_page_id = None
+            if link:
+                link_url = link.get("url")
+                link_page_id = link.get("page_id")
             return RichTextTextElement(
                 content=text["content"],
-                link_url=text["link"]["url"] if text.get("link") else None,
+                link_url=link_url,
+                link_page_id=link_page_id,
                 annotations=rich_text_element["annotations"],
                 plain_text=rich_text_element["plain_text"],
                 href=rich_text_element["href"],
@@ -106,24 +113,28 @@ class RichTextElement(metaclass=ABCMeta):
 class RichTextTextElement(RichTextElement):
     content: str
     link_url: str | None = None
+    link_page_id: str | None = None
 
     def __init__(
         self,
         content: str,
         link_url: str | None = None,
+        link_page_id: str | None = None,
         annotations: dict[str, bool] | None = None,
         plain_text: str | None = None,
         href: dict[str, bool] | None = None,
     ) -> None:
         self.content = content
         self.link_url = link_url
+        self.link_page_id = link_page_id
         super().__init__(annotations, plain_text, href)
 
     @staticmethod
-    def of(content: str, link_url: str | None = None) -> "RichTextTextElement":
+    def of(content: str, link_url: str | None = None, link_page_id: str | None = None) -> "RichTextTextElement":
         return RichTextTextElement(
             content=content,
             link_url=link_url,
+            link_page_id=link_page_id,
         )
 
     def to_slack_text(self) -> str:
@@ -135,11 +146,15 @@ class RichTextTextElement(RichTextElement):
     def get_type(self) -> str:
         return "text"
 
-    def to_dict_sub(self) -> str:
-        result = {
+    def to_dict_sub(self) -> dict:
+        result: dict[str, Any] = {
             "content": self.content,
         }
-        if self.link_url is not None:
+        if self.link_page_id is not None:
+            result["link"] = {
+                "page_id": self.link_page_id,
+            }
+        elif self.link_url is not None:
             result["link"] = {
                 "url": self.link_url,
             }

--- a/test/block/rich_text/test_rich_text_element.py
+++ b/test/block/rich_text/test_rich_text_element.py
@@ -2,10 +2,84 @@ from unittest import TestCase
 
 import pytest
 
-from lotion.block.rich_text.rich_text_element import RichTextElement
+from lotion.block.rich_text.rich_text_element import RichTextElement, RichTextTextElement
 
 
 class TestReadBlock(TestCase):
+    @pytest.mark.minimum()
+    def test_内部ページリンクを含むリッチテキストを扱える(self):
+        # Given: Notion APIから返される内部ページリンクを含むテキスト要素
+        input = {
+            "type": "text",
+            "text": {"content": "内部ページへのリンク", "link": {"page_id": "2ec6567a-3bbf-81b6-970c-cf6ad93ea8cc"}},
+            "annotations": {
+                "bold": False,
+                "italic": False,
+                "strikethrough": False,
+                "underline": False,
+                "code": False,
+                "color": "default",
+            },
+            "plain_text": "内部ページへのリンク",
+            "href": "/2ec6567a3bbf81b6970ccf6ad93ea8cc",
+        }
+
+        # When
+        rich_text = RichTextElement.from_entity(input)
+
+        # Then
+        self.assertIsInstance(rich_text, RichTextTextElement)
+        self.assertEqual(rich_text.content, "内部ページへのリンク")
+        self.assertEqual(rich_text.link_page_id, "2ec6567a-3bbf-81b6-970c-cf6ad93ea8cc")
+        self.assertIsNone(rich_text.link_url)
+
+    @pytest.mark.minimum()
+    def test_内部ページリンクをAPIに送信できる形式に変換できる(self):
+        # Given: 内部ページリンクを持つRichTextTextElement
+        element = RichTextTextElement.of(
+            content="内部ページへのリンク", link_page_id="2ec6567a-3bbf-81b6-970c-cf6ad93ea8cc"
+        )
+
+        # When
+        result = element.to_dict()
+
+        # Then
+        self.assertEqual(result["type"], "text")
+        self.assertEqual(result["text"]["content"], "内部ページへのリンク")
+        self.assertEqual(result["text"]["link"]["page_id"], "2ec6567a-3bbf-81b6-970c-cf6ad93ea8cc")
+        self.assertNotIn("url", result["text"]["link"])
+
+    @pytest.mark.minimum()
+    def test_外部URLリンクは従来通り動作する(self):
+        # Given: 外部URLリンクを持つテキスト要素
+        input = {
+            "type": "text",
+            "text": {"content": "外部リンク", "link": {"url": "https://example.com"}},
+            "annotations": {
+                "bold": False,
+                "italic": False,
+                "strikethrough": False,
+                "underline": False,
+                "code": False,
+                "color": "default",
+            },
+            "plain_text": "外部リンク",
+            "href": "https://example.com",
+        }
+
+        # When
+        rich_text = RichTextElement.from_entity(input)
+
+        # Then
+        self.assertIsInstance(rich_text, RichTextTextElement)
+        self.assertEqual(rich_text.link_url, "https://example.com")
+        self.assertIsNone(rich_text.link_page_id)
+
+        # And: API送信形式でもurlが使われる
+        result = rich_text.to_dict()
+        self.assertEqual(result["text"]["link"]["url"], "https://example.com")
+        self.assertNotIn("page_id", result["text"]["link"])
+
     @pytest.mark.minimum()
     def test_link_mentionのリッチテキストを扱える(self):
         # Given


### PR DESCRIPTION
Add support for Notion internal page links in RichTextTextElement. When Notion API returns an internal page reference, it uses link.page_id instead of link.url. This change allows the library to properly handle and serialize these internal links.

- Add link_page_id attribute to RichTextTextElement
- Update from_entity to parse both link.url and link.page_id
- Update to_dict_sub to serialize link.page_id when present
- Add tests for internal page link handling

Closes #83